### PR TITLE
Set timezone and bump tomcat version to 9.0.65

### DIFF
--- a/ansible/roles/fes-app-config/defaults/main.yml
+++ b/ansible/roles/fes-app-config/defaults/main.yml
@@ -3,7 +3,7 @@ s3_bucket: ""
 
 ansible_deploy_playbook_directory: "/root"
 
-tomcat_version: "9.0.62"
+tomcat_version: "9.0.65"
 tomcat_path: "/opt/tomcat"
 
 tomcat_environment: 

--- a/ansible/roles/fes-app-config/tasks/main.yml
+++ b/ansible/roles/fes-app-config/tasks/main.yml
@@ -5,6 +5,10 @@
     name: ['boto', 'boto3', 'botocore']
     umask: "0022"
 
+- name: Set timezone to Europe/London
+  timezone:
+    name: Europe/London
+
 - name: Download JDK installer from S3
   vars:
     ansible_python_interpreter: /usr/bin/python3


### PR DESCRIPTION
Set the timezone to Europe/London.
Update the version of tomcat to 9.0.65 (from 9.0.62) to pull in recent fixes.