### PR TITLE
Set correct timezone for FES app instead of system timezone

### DIFF
--- a/ansible/roles/fes-app-config/defaults/main.yml
+++ b/ansible/roles/fes-app-config/defaults/main.yml
@@ -14,3 +14,4 @@ tomcat_environment:
   - "CATALINA_PID={{ tomcat_path }}/latest/temp/tomcat.pid"
   - "CATALINA_OPTS=-Xms8192m -Xmx8192m -server -XX:+UseParallelGC" #Set this for actual memory
   - "PROPERTIES_FILE={{ tomcat_path }}/latest/webapps/FES.properties"
+  - "TZ=Europe/London"

--- a/ansible/roles/fes-app-config/tasks/main.yml
+++ b/ansible/roles/fes-app-config/tasks/main.yml
@@ -5,10 +5,6 @@
     name: ['boto', 'boto3', 'botocore']
     umask: "0022"
 
-- name: Set timezone to Europe/London
-  timezone:
-    name: Europe/London
-
 - name: Download JDK installer from S3
   vars:
     ansible_python_interpreter: /usr/bin/python3


### PR DESCRIPTION
Set the timezone via environment variable instead of altering the system clock timezone