### PR TITLE
Use tomcat 9.0.72 and download tomcat and fonts from S3

### DIFF
--- a/ansible/roles/fes-app-config/defaults/main.yml
+++ b/ansible/roles/fes-app-config/defaults/main.yml
@@ -3,8 +3,11 @@ s3_bucket: ""
 
 ansible_deploy_playbook_directory: "/root"
 
-tomcat_version: "9.0.65"
+tomcat_version: "9.0.72"
 tomcat_path: "/opt/tomcat"
+
+fonts_version: "1.0.1"
+fonts_path: "/usr/share"
 
 tomcat_environment: 
   - "JAVA_HOME=/usr/java/jdk1.8.0_172-amd64/jre"

--- a/ansible/roles/fes-app-config/tasks/main.yml
+++ b/ansible/roles/fes-app-config/tasks/main.yml
@@ -55,16 +55,35 @@
     state: present
   loop: "{{ package_installs }}"
 
-- name: Unarchive ch fonts
+- name: Download fonts from S3
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+  amazon.aws.aws_s3:
+    bucket: "{{ aws_s3_resource_bucket }}"
+    object: "chl-fes/fes-fonts-{{ fonts_version }}.tar"
+    dest: "/usr/share"
+    mode: get
+    overwrite: different
+    aws_access_key: "{{ aws_s3_resource_bucket_access_key | default(omit) }}"
+    aws_secret_key: "{{ aws_s3_resource_bucket_secret_key | default(omit) }}"
+
+- name: Unarchive fonts
   ansible.builtin.unarchive:
-    src: "http://repository.aws.chdev.org:8081/artifactory/local-ch-release/uk/gov/companieshouse/chips-fop-fonts/1.0.1/chips-fop-fonts-1.0.1.tar"
+    src: "/usr/share/fes-fonts-{{ fonts_version }}.tar"
     dest: "/usr/share"
     remote_src: yes
 
-- name: Download tomcat
-  ansible.builtin.get_url: 
-    url: "https://downloads.apache.org/tomcat/tomcat-{{ tomcat_version.split('.')[0] }}/v{{ tomcat_version }}/bin/apache-tomcat-{{ tomcat_version }}.tar.gz"
+- name: Download tomcat from S3
+  vars:
+    ansible_python_interpreter: /usr/bin/python3
+  amazon.aws.aws_s3:
+    bucket: "{{ aws_s3_resource_bucket }}"
+    object: "chl-fes/apache-tomcat-{{ tomcat_version }}.tar.gz"
     dest: "/tmp"
+    mode: get
+    overwrite: different
+    aws_access_key: "{{ aws_s3_resource_bucket_access_key | default(omit) }}"
+    aws_secret_key: "{{ aws_s3_resource_bucket_secret_key | default(omit) }}"
 
 - name: Create tomcat directory
   ansible.builtin.file:

--- a/ansible/roles/fes-app-config/tasks/main.yml
+++ b/ansible/roles/fes-app-config/tasks/main.yml
@@ -61,7 +61,7 @@
   amazon.aws.aws_s3:
     bucket: "{{ aws_s3_resource_bucket }}"
     object: "chl-fes/fes-fonts-{{ fonts_version }}.tar"
-    dest: "/usr/share"
+    dest: "{{ fonts_path }}"
     mode: get
     overwrite: different
     aws_access_key: "{{ aws_s3_resource_bucket_access_key | default(omit) }}"
@@ -70,7 +70,7 @@
 - name: Unarchive fonts
   ansible.builtin.unarchive:
     src: "/usr/share/fes-fonts-{{ fonts_version }}.tar"
-    dest: "/usr/share"
+    dest: "{{ fonts_path }}"
     remote_src: yes
 
 - name: Download tomcat from S3

--- a/ansible/roles/fes-app-config/tasks/main.yml
+++ b/ansible/roles/fes-app-config/tasks/main.yml
@@ -69,7 +69,7 @@
 
 - name: Unarchive fonts
   ansible.builtin.unarchive:
-    src: "/usr/share/fes-fonts-{{ fonts_version }}.tar"
+    src: "{{ fonts_path }}/fes-fonts-{{ fonts_version }}.tar"
     dest: "{{ fonts_path }}"
     remote_src: yes
 


### PR DESCRIPTION
Download the tomcat package S3 instead of from the Apache website.  The AMI build was breaking 
when the Apache download link changed, such as when a new version of tomcat was released.
Additionally, bump tomcat version to 9.0.72 and also download a FES specific fonts archive from S3 instead of artifactory.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1456