### PR TITLE
Remove ch_collections role as nfs not used on FES

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -3,6 +3,5 @@
   become: true
   gather_facts: yes
   roles:
-    - ch_collections.heritage_services.nfs
     - fes-app-config
 


### PR DESCRIPTION
We are hitting an AMI build issue with a yum lock file, which can be fixed by increasing the lock_timeout, but we don't actually need these packages installed as we don't use nfs on FES, so we can resolve more cleanly by removing the ch_collections role.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1456
