### PR TITLE
Correct the destination file path when downloading from S3

### DIFF
--- a/ansible/roles/fes-app-config/tasks/main.yml
+++ b/ansible/roles/fes-app-config/tasks/main.yml
@@ -61,7 +61,7 @@
   amazon.aws.aws_s3:
     bucket: "{{ aws_s3_resource_bucket }}"
     object: "chl-fes/fes-fonts-{{ fonts_version }}.tar"
-    dest: "{{ fonts_path }}"
+    dest: "{{ fonts_path }}/fes-fonts-{{ fonts_version }}.tar"
     mode: get
     overwrite: different
     aws_access_key: "{{ aws_s3_resource_bucket_access_key | default(omit) }}"
@@ -79,7 +79,7 @@
   amazon.aws.aws_s3:
     bucket: "{{ aws_s3_resource_bucket }}"
     object: "chl-fes/apache-tomcat-{{ tomcat_version }}.tar.gz"
-    dest: "/tmp"
+    dest: "/tmp/apache-tomcat-{{ tomcat_version }}.tar.gz"
     mode: get
     overwrite: different
     aws_access_key: "{{ aws_s3_resource_bucket_access_key | default(omit) }}"


### PR DESCRIPTION
Fix to add the filename as part of the destination path, when downloading from S3, as that is required by the S3 module.

Resolves:
https://companieshouse.atlassian.net/browse/CM-1456