### PR TITLE
Add lock_timeout for yum installs to avoid intermittent lock error

### DIFF
--- a/ansible/roles/fes-app-config/tasks/main.yml
+++ b/ansible/roles/fes-app-config/tasks/main.yml
@@ -32,6 +32,7 @@
   package:
     name: "/tmp/jdk-8u172-linux-x64.rpm"
     state: present
+    lock_timeout: 60
 
 - name: Create user groups
   ansible.builtin.group:
@@ -53,6 +54,7 @@
   yum:
     name: "{{ item }}"
     state: present
+    lock_timeout: 60
   loop: "{{ package_installs }}"
 
 - name: Download fonts from S3


### PR DESCRIPTION
The ami-fes build pipeline has been failing intermittently with a yum lock error:

`amazon-ebs.builder: failed: [fes-app] (item=autofs) => {"ansible_loop_var": "item", "changed": false, "item": "autofs", "msg": "yum lockfile is held by another process"}`

This change adds a parameter to allow longer to wait (60 secs) for the lock to be freed.

Resolves:
https://companieshouse.atlassian.net/browse/DVOP-2689
